### PR TITLE
R console changes

### DIFF
--- a/src/app/rstats/qgsrstatsconsole.cpp
+++ b/src/app/rstats/qgsrstatsconsole.cpp
@@ -63,12 +63,13 @@ QgsRStatsConsole::QgsRStatsConsole( QWidget *parent, QgsRStatsRunner *runner )
   {
     mOutput->setHtml( mOutput->toHtml() + QStringLiteral( "<p style=\"color: red\">%1</p>" ).arg( error ) );
   } );
+
   connect( mRunner, &QgsRStatsRunner::commandFinished, this, [ = ]( const QVariant & result )
   {
-    if ( !result.isValid() )
-      mOutput->append( "NA" );
-    else
-      mOutput->append( result.toString() );
+    //if ( !result.isValid() )
+    //  mOutput->append( "NA" );
+    //else
+    //  mOutput->append( result.toString() );
   } );
 
   connect( mRunner, &QgsRStatsRunner::consoleMessage, this, [ = ]( const QString & message, int type )

--- a/src/app/rstats/qgsrstatsrunner.cpp
+++ b/src/app/rstats/qgsrstatsrunner.cpp
@@ -110,6 +110,9 @@ QVariant QgsRStatsSession::execCommand( const QString &command, QString &error )
   try
   {
     SEXP res = mRSession->parseEval( command.toStdString() );
+
+    WriteConsole(sexpToString(res), 0);
+
     switch ( TYPEOF( res ) )
     {
       case NILSXP:

--- a/src/app/rstats/qgsrstatsrunner.cpp
+++ b/src/app/rstats/qgsrstatsrunner.cpp
@@ -91,6 +91,20 @@ QgsRStatsSession::QgsRStatsSession()
 
 QgsRStatsSession::~QgsRStatsSession() = default;
 
+std::string QgsRStatsSession::sexpToString(const SEXP exp)
+{
+    Rcpp::StringVector lines = Rcpp::StringVector(Rf_eval(Rf_lang2(Rf_install("capture.output"), exp), R_GlobalEnv));
+    std::string outcome = "";
+    for (auto it = lines.begin(); it != lines.end(); it++)
+    {
+        Rcpp::String line(it->get());
+        outcome.append(line);
+        if (it < lines.end() - 1)
+            outcome.append("\n");
+    }
+    return outcome;
+}
+
 QVariant QgsRStatsSession::execCommand( const QString &command, QString &error )
 {
   try

--- a/src/app/rstats/qgsrstatsrunner.cpp
+++ b/src/app/rstats/qgsrstatsrunner.cpp
@@ -120,23 +120,38 @@ QVariant QgsRStatsSession::execCommand( const QString &command, QString &error )
 
       case LGLSXP:
       {
-        const int resInt = Rcpp::as<int>( res );
-        if ( resInt < 0 )
-          return QVariant();
+        if (LENGTH(res) == 1)
+        {
+            const int resInt = Rcpp::as<int>( res );
+            if ( resInt < 0 )
+              return QVariant();
+            else
+              return static_cast< bool >( resInt );
+        }
         else
-          return static_cast< bool >( resInt );
+            return QVariant();
+
       }
 
       case INTSXP:
         // handle NA_integer_ as NA!
-        return Rcpp::as<int>( res );
+        if (LENGTH(res) == 1)
+            return Rcpp::as<int>( res );
+        else
+            return QVariant();
 
       case REALSXP:
         // handle nan as NA
-        return Rcpp::as<double>( res );
+        if (LENGTH(res) == 1)
+            return Rcpp::as<double>( res );
+        else
+            return QVariant();
 
       case STRSXP:
-        return QString::fromStdString( Rcpp::as<std::string>( res ) );
+        if (LENGTH(res) == 1)
+            return QString::fromStdString( Rcpp::as<std::string>( res ) );
+        else
+            return QVariant();
 
       //case RAWSXP:
       //  return R::rawPointer( res );

--- a/src/app/rstats/qgsrstatsrunner.h
+++ b/src/app/rstats/qgsrstatsrunner.h
@@ -76,6 +76,7 @@ class QgsRStatsSession: public QObject, public Callbacks
     std::unique_ptr< RInside > mRSession;
     bool mBusy = false;
 
+    std::string sexpToString(const SEXP exp);
 };
 
 


### PR DESCRIPTION
Handles printing of objects by R means, which means that expressions are evaluated in the same way as in R command line or RStudio. Makes it very easy to print even data.frames. Test by inputing  `mtcars` into console.

The `QgsRStatsSession::execCommand` only returns valid value if the SEXP is of length 1, otherwise it returns empty `QVariant()` for now, to avoid errors in the console output.Possibly `QList` of values should be returned for R vectors?