### PR TITLE
More update on Settings help links

### DIFF
--- a/src/app/3d/qgs3doptions.cpp
+++ b/src/app/3d/qgs3doptions.cpp
@@ -63,7 +63,7 @@ Qgs3DOptionsWidget::Qgs3DOptionsWidget( QWidget *parent )
 QString Qgs3DOptionsWidget::helpKey() const
 {
   // typo IS correct here!
-  return QStringLiteral( "introduction/qgis_configuration.html#d-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#d-options" );
 }
 
 void Qgs3DOptionsWidget::apply()

--- a/src/app/options/qgsadvancedoptions.cpp
+++ b/src/app/options/qgsadvancedoptions.cpp
@@ -63,12 +63,12 @@ QgsAdvancedSettingsWidget::~QgsAdvancedSettingsWidget()
 
 QString QgsAdvancedSettingsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#advanced-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#optionsadvanced" );
 }
 
 void QgsAdvancedSettingsWidget::apply()
 {
-  // the old settings editor  applies changes immediately
+  // the old settings editor applies changes immediately
   // new settings tree is performing changes on apply
   if ( mTreeWidget )
     mTreeWidget->applyChanges();

--- a/src/app/options/qgscodeeditoroptions.cpp
+++ b/src/app/options/qgscodeeditoroptions.cpp
@@ -358,7 +358,7 @@ QgsCodeEditorOptionsWidget::~QgsCodeEditorOptionsWidget()
 
 QString QgsCodeEditorOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#code-editor-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#code-editor-options" );
 }
 
 void QgsCodeEditorOptionsWidget::apply()

--- a/src/app/options/qgselevationoptions.cpp
+++ b/src/app/options/qgselevationoptions.cpp
@@ -40,7 +40,7 @@ QgsElevationOptionsWidget::QgsElevationOptionsWidget( QWidget *parent )
 
 QString QgsElevationOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#elevation-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#elevation-options" );
 }
 
 void QgsElevationOptionsWidget::apply()

--- a/src/app/options/qgsfontoptions.cpp
+++ b/src/app/options/qgsfontoptions.cpp
@@ -106,7 +106,7 @@ QgsFontOptionsWidget::QgsFontOptionsWidget( QWidget *parent )
 
 QString QgsFontOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#fonts-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#fonts-options" );
 }
 
 void QgsFontOptionsWidget::apply()

--- a/src/app/options/qgsgpsdeviceoptions.cpp
+++ b/src/app/options/qgsgpsdeviceoptions.cpp
@@ -91,7 +91,7 @@ QgsGpsDeviceOptionsWidget::QgsGpsDeviceOptionsWidget( QWidget *parent )
 
 QString QgsGpsDeviceOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#gpsbabel" );
+  return QStringLiteral( "introduction/qgis_configuration.html#defining-new-device" );
 }
 
 void QgsGpsDeviceOptionsWidget::apply()

--- a/src/app/options/qgsgpsoptions.cpp
+++ b/src/app/options/qgsgpsoptions.cpp
@@ -315,7 +315,7 @@ QgsGpsOptionsWidget::QgsGpsOptionsWidget( QWidget *parent )
 
 QString QgsGpsOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#gps-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#gps-options" );
 }
 
 void QgsGpsOptionsWidget::apply()

--- a/src/app/options/qgsoptions.cpp
+++ b/src/app/options/qgsoptions.cpp
@@ -2807,13 +2807,65 @@ void QgsOptions::showHelp()
   {
     link = QStringLiteral( "introduction/qgis_configuration.html" );
 
-    if ( activeTab == mOptionsPageAuth )
+    if ( activeTab == mOptionsPageGeneral )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#general-options" );
+    }
+    else if ( activeTab == mOptionsPageSystem )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#env-options" );
+    }
+    else if ( activeTab == mOptionsPageTransformations )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#transformations-options" );
+    }
+    else if ( activeTab == mOptionsPageDataSources )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#datasources-options" );
+    }
+    else if ( activeTab == mOptionsPageGDAL )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#gdal-options" );
+    }
+    else if ( activeTab == mOptionsPageMapCanvas )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#canvas-legend-options" );
+    }
+    else if ( activeTab == mOptionsPageMapTools )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#maptools-options" );
+    }
+    else if ( activeTab == mOptionsPageDigitizing )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#digitizing-options" );
+    }
+    else if ( activeTab == mOptionsPageColors )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#colors-options" );
+    }
+    else if ( activeTab == mOptionsPageComposer )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#layout-options" );
+    }
+    else if ( activeTab == mOptionsPageNetwork )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#network-options" );
+    }
+    else if ( activeTab == mOptionsLocatorSettings )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#locator-options" );
+    }
+    else if ( activeTab == mOptionsPageAcceleration )
+    {
+      link = QStringLiteral( "introduction/qgis_configuration.html#acceleration-options" );
+    }
+    else if ( activeTab == mOptionsPageAuth )
     {
       link = QStringLiteral( "auth_system/index.html" );
     }
     else if ( activeTab == mOptionsPageVariables )
     {
-      link = QStringLiteral( "introduction/general_tools.html#variables" );
+      link = QStringLiteral( "introduction/general_tools.html#general-tools-variables" );
     }
     else if ( activeTab == mOptionsPageCRS )
     {

--- a/src/app/options/qgsrasterrenderingoptions.cpp
+++ b/src/app/options/qgsrasterrenderingoptions.cpp
@@ -80,7 +80,7 @@ QgsRasterRenderingOptionsWidget::QgsRasterRenderingOptionsWidget( QWidget *paren
 
 QString QgsRasterRenderingOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#raster-rendering-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#raster-rendering-options" );
 }
 
 void QgsRasterRenderingOptionsWidget::apply()

--- a/src/app/options/qgsrenderingoptions.cpp
+++ b/src/app/options/qgsrenderingoptions.cpp
@@ -57,7 +57,7 @@ QgsRenderingOptionsWidget::QgsRenderingOptionsWidget( QWidget *parent )
 
 QString QgsRenderingOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#rendering-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#rendering-options" );
 }
 
 void QgsRenderingOptionsWidget::apply()

--- a/src/app/options/qgsuserprofileoptions.cpp
+++ b/src/app/options/qgsuserprofileoptions.cpp
@@ -80,6 +80,11 @@ QgsUserProfileOptionsWidget::QgsUserProfileOptionsWidget( QWidget *parent )
   mActiveProfileIconLabel->setText( tr( "Active Profile (%1) icon", "Active profile icon" ).arg( manager->userProfile()->name() ) );
 }
 
+QString QgsUserProfileOptionsWidget::helpKey() const
+{
+  return QStringLiteral( "introduction/qgis_configuration.html#user-profiles" );
+}
+
 void QgsUserProfileOptionsWidget::apply()
 {
   QgsUserProfileManager *manager = QgisApp::instance()->userProfileManager();

--- a/src/app/options/qgsuserprofileoptions.h
+++ b/src/app/options/qgsuserprofileoptions.h
@@ -34,7 +34,7 @@ class APP_EXPORT QgsUserProfileOptionsWidget : public QgsOptionsPageWidget, priv
 
     //! Constructor for QgsUserProfileOptionsWidget with the specified \a parent widget.
     QgsUserProfileOptionsWidget( QWidget *parent );
-
+    QString helpKey() const override;
     void apply() override;
 
   private slots:

--- a/src/app/options/qgsvectorrenderingoptions.cpp
+++ b/src/app/options/qgsvectorrenderingoptions.cpp
@@ -70,7 +70,7 @@ QgsVectorRenderingOptionsWidget::QgsVectorRenderingOptionsWidget( QWidget *paren
 
 QString QgsVectorRenderingOptionsWidget::helpKey() const
 {
-  return QStringLiteral( "introduction/qgis_configuration.html#vector-rendering-settings" );
+  return QStringLiteral( "introduction/qgis_configuration.html#vector-rendering-options" );
 }
 
 void QgsVectorRenderingOptionsWidget::apply()

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -568,7 +568,7 @@ bool QgsCustomizationDialog::catchOn()
 
 void QgsCustomizationDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#customization" ) );
+  QgsHelp::openHelp( QStringLiteral( "introduction/qgis_configuration.html#sec-customization" ) );
 }
 
 


### PR DESCRIPTION
Hi Nyall,
* Instead of using the user visible section title that may change in the future (either in the GUI or because we use a different type of titling in the docs) I suggest we rely on the sections anchors that almost never change.
* While at it, instead of customizing links for only the tabs that do not belong to the Options ui file, I suggest we use direct links for the other tabs too. Not sure if the "if .. else if" style is the more appropriate.
* Last, I add a help link for the User profile tab also (but still remains the last screenshot at https://github.com/qgis/QGIS/pull/53569#issue-1772454336)